### PR TITLE
Fix bug causing wrong stack boundaries to be reported

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@
 .DS_Store
 .vscode
 .directory
+cmake-build*/
+.idea/


### PR DESCRIPTION
This should fix a crash when running WebCore inside environments where the stack has an unusual layout