### PR TITLE
Extend WebCore with new class version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,6 @@
 .directory
 cmake-build*/
 .idea/
+.vs/
+CMakeSettings.json
+out/

--- a/Source/JavaScriptCore/API/APICallbackFunction.h
+++ b/Source/JavaScriptCore/API/APICallbackFunction.h
@@ -37,6 +37,7 @@ namespace JSC {
 struct APICallbackFunction {
 
 template <typename T> static EncodedJSValue JSC_HOST_CALL call(ExecState*);
+template <typename T> static EncodedJSValue JSC_HOST_CALL call_ex(ExecState*);
 template <typename T> static EncodedJSValue JSC_HOST_CALL construct(ExecState*);
 
 };
@@ -61,6 +62,39 @@ EncodedJSValue JSC_HOST_CALL APICallbackFunction::call(ExecState* exec)
     {
         JSLock::DropAllLocks dropAllLocks(exec);
         result = jsCast<T*>(toJS(functionRef))->functionCallback()(execRef, functionRef, thisObjRef, argumentCount, arguments.data(), &exception);
+    }
+    if (exception)
+        throwException(exec, scope, toJS(exec, exception));
+
+    // result must be a valid JSValue.
+    if (!result)
+        return JSValue::encode(jsUndefined());
+
+    return JSValue::encode(toJS(exec, result));
+}
+
+template <typename T>
+EncodedJSValue JSC_HOST_CALL APICallbackFunction::call_ex(ExecState* exec)
+{
+    VM& vm = exec->vm();
+    auto scope = DECLARE_THROW_SCOPE(vm);
+    JSContextRef execRef = toRef(exec);
+    JSObjectRef functionRef = toRef(exec->jsCallee());
+    JSObjectRef thisObjRef = toRef(jsCast<JSObject*>(exec->thisValue().toThis(exec, NotStrictMode)));
+
+    int argumentCount = static_cast<int>(exec->argumentCount());
+    Vector<JSValueRef, 16> arguments;
+    arguments.reserveInitialCapacity(argumentCount);
+    for (int i = 0; i < argumentCount; i++)
+        arguments.uncheckedAppend(toRef(exec, exec->uncheckedArgument(i)));
+
+    JSValueRef exception = 0;
+    JSValueRef result;
+    {
+        JSLock::DropAllLocks dropAllLocks(exec);
+        T* functionInstance = jsCast<T*>(toJS(functionRef));
+
+        result = functionInstance->functionCallbackEx()(execRef, functionInstance->callClass(), functionRef, thisObjRef, argumentCount, arguments.data(), &exception);
     }
     if (exception)
         throwException(exec, scope, toJS(exec, exception));

--- a/Source/JavaScriptCore/API/APICallbackFunction.h
+++ b/Source/JavaScriptCore/API/APICallbackFunction.h
@@ -94,7 +94,8 @@ EncodedJSValue JSC_HOST_CALL APICallbackFunction::call_ex(ExecState* exec)
         JSLock::DropAllLocks dropAllLocks(exec);
         T* functionInstance = jsCast<T*>(toJS(functionRef));
 
-        result = functionInstance->functionCallbackEx()(execRef, functionInstance->callClass(), functionRef, thisObjRef, argumentCount, arguments.data(), &exception);
+        RefPtr<OpaqueJSString> name = OpaqueJSString::tryCreate(functionInstance->name());
+        result = functionInstance->functionCallbackEx()(execRef, functionInstance->callClass(), name.get(), functionRef, thisObjRef, argumentCount, arguments.data(), &exception);
     }
     if (exception)
         throwException(exec, scope, toJS(exec, exception));

--- a/Source/JavaScriptCore/API/JSCallbackFunction.cpp
+++ b/Source/JavaScriptCore/API/JSCallbackFunction.cpp
@@ -49,6 +49,14 @@ JSCallbackFunction::JSCallbackFunction(VM& vm, Structure* structure, JSObjectCal
 {
 }
 
+JSCallbackFunction::JSCallbackFunction(VM& vm, Structure* structure, JSClassRef clazz, JSObjectCallAsFunctionCallbackEx callback)
+    : InternalFunction(vm, structure, APICallbackFunction::call_ex<JSCallbackFunction>, nullptr)
+    , m_callbackEx(callback)
+    , m_clazz(clazz)
+{
+}
+
+
 void JSCallbackFunction::finishCreation(VM& vm, const String& name)
 {
     Base::finishCreation(vm, name);
@@ -59,6 +67,14 @@ JSCallbackFunction* JSCallbackFunction::create(VM& vm, JSGlobalObject* globalObj
 {
     Structure* structure = globalObject->callbackFunctionStructure();
     JSCallbackFunction* function = new (NotNull, allocateCell<JSCallbackFunction>(vm.heap)) JSCallbackFunction(vm, structure, callback);
+    function->finishCreation(vm, name);
+    return function;
+}
+
+JSCallbackFunction* JSCallbackFunction::create(VM& vm, JSGlobalObject* globalObject, JSClassRef clazz, JSObjectCallAsFunctionCallbackEx callback, const String& name)
+{
+    Structure* structure = globalObject->callbackFunctionStructure();
+    JSCallbackFunction* function = new (NotNull, allocateCell<JSCallbackFunction>(vm.heap)) JSCallbackFunction(vm, structure, clazz, callback);
     function->finishCreation(vm, name);
     return function;
 }

--- a/Source/JavaScriptCore/API/JSCallbackFunction.h
+++ b/Source/JavaScriptCore/API/JSCallbackFunction.h
@@ -43,6 +43,7 @@ public:
     }
 
     static JSCallbackFunction* create(VM&, JSGlobalObject*, JSObjectCallAsFunctionCallback, const String& name);
+    static JSCallbackFunction* create(VM&, JSGlobalObject*, JSClassRef, JSObjectCallAsFunctionCallbackEx, const String& name);
 
     DECLARE_INFO;
     
@@ -55,11 +56,23 @@ public:
 
 private:
     JSCallbackFunction(VM&, Structure*, JSObjectCallAsFunctionCallback);
+    JSCallbackFunction(VM&, Structure*, JSClassRef, JSObjectCallAsFunctionCallbackEx);
     void finishCreation(VM&, const String& name);
 
     JSObjectCallAsFunctionCallback functionCallback() { return m_callback; }
 
-    JSObjectCallAsFunctionCallback m_callback { nullptr };
+    JSObjectCallAsFunctionCallbackEx functionCallbackEx() { return m_callbackEx; }
+
+    JSClassRef callClass() { return m_clazz; }
+
+    union {
+        JSObjectCallAsFunctionCallback m_callback{ nullptr };
+
+        struct {
+            JSObjectCallAsFunctionCallbackEx m_callbackEx;
+            JSClassRef m_clazz;
+        };
+    };
 };
 
 } // namespace JSC

--- a/Source/JavaScriptCore/API/JSCallbackObjectFunctions.h
+++ b/Source/JavaScriptCore/API/JSCallbackObjectFunctions.h
@@ -588,8 +588,10 @@ EncodedJSValue JSCallbackObject<Parent>::call(ExecState* exec)
             JSValue result;
             {
                 JSLock::DropAllLocks dropAllLocks(exec);
+
+                RefPtr<OpaqueJSString> className = jsClass->version == 1000 ? OpaqueJSString::tryCreate(jsClass->className()) : nullptr;
                 result = toJS(exec, callAsFunction ? callAsFunction(execRef, functionRef, thisObjRef, argumentCount, arguments.data(), &exception) :
-                    callAsFunctionEx(execRef, jsClass, functionRef, thisObjRef, argumentCount, arguments.data(), &exception));
+                    callAsFunctionEx(execRef, jsClass, className.get(), functionRef, thisObjRef, argumentCount, arguments.data(), &exception));
             }
             if (exception)
                 throwException(exec, scope, toJS(exec, exception));

--- a/Source/JavaScriptCore/API/JSCallbackObjectFunctions.h
+++ b/Source/JavaScriptCore/API/JSCallbackObjectFunctions.h
@@ -39,15 +39,6 @@
 #include <wtf/Vector.h>
 
 namespace JSC {
-    namespace CallbackObjectHelpers
-    {
-        struct VersionedInitRoutine
-        {
-            int version;
-            JSClassRef clazz;
-        };
-    }
-
 template <class Parent>
 inline JSCallbackObject<Parent>* JSCallbackObject<Parent>::asCallbackObject(JSValue value)
 {

--- a/Source/JavaScriptCore/API/JSCallbackObjectFunctions.h
+++ b/Source/JavaScriptCore/API/JSCallbackObjectFunctions.h
@@ -309,20 +309,18 @@ bool JSCallbackObject<Parent>::put(JSCell* cell, ExecState* exec, PropertyName p
                     if (entry->attributes & kJSPropertyAttributeReadOnly)
                         return false;
 
-                    if ((entry->version == 0 && setProperty) || (entry->version == 1000 && setPropertyEx)) {
-                        if (JSObjectSetPropertyCallback setProperty = entry->v0.setProperty) {
-                            JSValueRef exception = 0;
-                            bool result;
-                            {
-                                JSLock::DropAllLocks dropAllLocks(exec);
-                                result = setProperty ? setProperty(ctx, thisRef, entry->propertyNameRef.get(), valueRef, &exception) :
-                                    setPropertyEx(ctx, jsClass, thisRef, entry->propertyNameRef.get(), valueRef, &exception);
-                            }
-                            if (exception)
-                                throwException(exec, scope, toJS(exec, exception));
-                            if (result || exception)
-                                return result;
+                    if ((entry->version == 0 && entry->v0.setProperty) || (entry->version == 1000 && entry->v1000.setPropertyEx)) {
+                        JSValueRef exception = 0;
+                        bool result;
+                        {
+                            JSLock::DropAllLocks dropAllLocks(exec);
+                            result = entry->version == 0 ? entry->v0.setProperty(ctx, thisRef, entry->propertyNameRef.get(), valueRef, &exception) :
+                                entry->v1000.setPropertyEx(ctx, jsClass, thisRef, entry->propertyNameRef.get(), valueRef, &exception);
                         }
+                        if (exception)
+                            throwException(exec, scope, toJS(exec, exception));
+                        if (result || exception)
+                            return result;
                     }
                 }
             }

--- a/Source/JavaScriptCore/API/JSCallbackObjectFunctions.h
+++ b/Source/JavaScriptCore/API/JSCallbackObjectFunctions.h
@@ -734,7 +734,7 @@ EncodedJSValue JSCallbackObject<Parent>::staticFunctionGetter(ExecState* exec, E
                         return JSValue::encode(o);
                     } else if(entry->version == 1000 && entry->v1000.callAsFunctionEx)
                     {
-                        JSObject* o = JSCallbackFunction::create(vm, thisObj->globalObject(vm), jsClass, entry->v1000.callAsFunctionEx, name);
+                        JSObject* o = JSCallbackFunction::create(vm, thisObj->globalObject(vm), entry->v1000.owner, entry->v1000.callAsFunctionEx, name);
                         thisObj->putDirect(vm, propertyName, o, entry->attributes);
                         return JSValue::encode(o);
                     }

--- a/Source/JavaScriptCore/API/JSCallbackObjectFunctions.h
+++ b/Source/JavaScriptCore/API/JSCallbackObjectFunctions.h
@@ -39,6 +39,14 @@
 #include <wtf/Vector.h>
 
 namespace JSC {
+    namespace CallbackObjectHelpers
+    {
+        struct VersionedInitRoutine
+        {
+            int version;
+            JSClassRef clazz;
+        };
+    }
 
 template <class Parent>
 inline JSCallbackObject<Parent>* JSCallbackObject<Parent>::asCallbackObject(JSValue value)
@@ -80,8 +88,12 @@ JSCallbackObject<Parent>::~JSCallbackObject()
     vm->currentlyDestructingCallbackObjectClassInfo = m_classInfo;
     JSObjectRef thisRef = toRef(static_cast<JSObject*>(this));
     for (JSClassRef jsClass = classRef(); jsClass; jsClass = jsClass->parentClass) {
-        if (JSObjectFinalizeCallback finalize = jsClass->finalize)
-            finalize(thisRef);
+        if (jsClass->version == 0 && jsClass->v0.finalize != nullptr) {
+            jsClass->v0.finalize(thisRef);
+        } else if(jsClass->version == 1000 && jsClass->v1000.finalizeEx != nullptr)
+        {
+            jsClass->v1000.finalizeEx(jsClass, thisRef);
+        }
     }
     vm->currentlyDestructingCallbackObject = nullptr;
     vm->currentlyDestructingCallbackObjectClassInfo = nullptr;
@@ -110,19 +122,24 @@ template <class Parent>
 void JSCallbackObject<Parent>::init(ExecState* exec)
 {
     ASSERT(exec);
-    
-    Vector<JSObjectInitializeCallback, 16> initRoutines;
+
+    Vector<JSClassRef, 16> initRoutines;
     JSClassRef jsClass = classRef();
     do {
-        if (JSObjectInitializeCallback initialize = jsClass->initialize)
-            initRoutines.append(initialize);
+        initRoutines.append(jsClass);
     } while ((jsClass = jsClass->parentClass));
     
     // initialize from base to derived
     for (int i = static_cast<int>(initRoutines.size()) - 1; i >= 0; i--) {
         JSLock::DropAllLocks dropAllLocks(exec);
-        JSObjectInitializeCallback initialize = initRoutines[i];
-        initialize(toRef(exec), toRef(this));
+        JSClassRef clazz = initRoutines[i];
+
+        if (clazz->version == 0 && clazz->v0.initialize) {
+            clazz->v0.initialize(toRef(exec), toRef(this));
+        } else if(clazz->version == 1000 && clazz->v1000.initializeEx)
+        {
+            clazz->v1000.initializeEx(toRef(exec), clazz, toRef(this));
+        }
     }
     
     m_classInfo = this->classInfo();
@@ -161,23 +178,35 @@ bool JSCallbackObject<Parent>::getOwnPropertySlot(JSObject* object, ExecState* e
     
     if (StringImpl* name = propertyName.uid()) {
         for (JSClassRef jsClass = thisObject->classRef(); jsClass; jsClass = jsClass->parentClass) {
+            JSObjectHasPropertyCallback hasProperty = jsClass->version == 0 ? jsClass->v0.hasProperty : nullptr;
+            JSObjectHasPropertyCallbackEx hasPropertyEx = jsClass->version == 1000 ? jsClass->v1000.hasPropertyEx : nullptr;
+
+            JSObjectGetPropertyCallback getProperty = jsClass->version == 0 ? jsClass->v0.getProperty : nullptr;
+            JSObjectGetPropertyCallbackEx getPropertyEx = jsClass->version == 1000 ? jsClass->v1000.getPropertyEx : nullptr;
+
             // optional optimization to bypass getProperty in cases when we only need to know if the property exists
-            if (JSObjectHasPropertyCallback hasProperty = jsClass->hasProperty) {
+            if (hasProperty || hasPropertyEx) {
                 if (!propertyNameRef)
                     propertyNameRef = OpaqueJSString::tryCreate(name);
                 JSLock::DropAllLocks dropAllLocks(exec);
-                if (hasProperty(ctx, thisRef, propertyNameRef.get())) {
+
+                bool doesHaveProperty = hasProperty ? hasProperty(ctx, thisRef, propertyNameRef.get()) :
+                    hasPropertyEx(ctx, jsClass, thisRef, propertyNameRef.get());
+
+                if (doesHaveProperty) {
                     slot.setCustom(thisObject, PropertyAttribute::ReadOnly | PropertyAttribute::DontEnum, callbackGetter);
                     return true;
                 }
-            } else if (JSObjectGetPropertyCallback getProperty = jsClass->getProperty) {
+            }
+            else if (getProperty || getPropertyEx) {
                 if (!propertyNameRef)
                     propertyNameRef = OpaqueJSString::tryCreate(name);
                 JSValueRef exception = 0;
                 JSValueRef value;
                 {
                     JSLock::DropAllLocks dropAllLocks(exec);
-                    value = getProperty(ctx, thisRef, propertyNameRef.get(), &exception);
+                    value = getProperty ? getProperty(ctx, thisRef, propertyNameRef.get(), &exception) :
+                        getPropertyEx(ctx, jsClass, thisRef, propertyNameRef.get(), &exception);
                 }
                 if (exception) {
                     throwException(exec, scope, toJS(exec, exception));
@@ -189,6 +218,7 @@ bool JSCallbackObject<Parent>::getOwnPropertySlot(JSObject* object, ExecState* e
                     return true;
                 }
             }
+            
             
             if (OpaqueJSClassStaticValuesTable* staticValues = jsClass->staticValues(exec)) {
                 if (staticValues->contains(name)) {
@@ -230,9 +260,13 @@ JSValue JSCallbackObject<Parent>::defaultValue(const JSObject* object, ExecState
     ::JSType jsHint = hint == PreferString ? kJSTypeString : kJSTypeNumber;
 
     for (JSClassRef jsClass = thisObject->classRef(); jsClass; jsClass = jsClass->parentClass) {
-        if (JSObjectConvertToTypeCallback convertToType = jsClass->convertToType) {
+        JSObjectConvertToTypeCallback convertToType = jsClass->version == 0 ? jsClass->v0.convertToType : nullptr;
+        JSObjectConvertToTypeCallbackEx convertToTypeEx = jsClass->version == 1000 ? jsClass->v1000.convertToTypeEx : nullptr;
+
+        if (convertToType || convertToTypeEx) {
             JSValueRef exception = 0;
-            JSValueRef result = convertToType(ctx, thisRef, jsHint, &exception);
+            JSValueRef result = convertToType ? convertToType(ctx, thisRef, jsHint, &exception) :
+                convertToTypeEx(ctx, jsClass, thisRef, jsHint, &exception);
             if (exception) {
                 throwException(exec, scope, toJS(exec, exception));
                 return jsUndefined();
@@ -259,14 +293,18 @@ bool JSCallbackObject<Parent>::put(JSCell* cell, ExecState* exec, PropertyName p
     
     if (StringImpl* name = propertyName.uid()) {
         for (JSClassRef jsClass = thisObject->classRef(); jsClass; jsClass = jsClass->parentClass) {
-            if (JSObjectSetPropertyCallback setProperty = jsClass->setProperty) {
+            JSObjectSetPropertyCallback setProperty = jsClass->version == 0 ? jsClass->v0.setProperty : nullptr;
+            JSObjectSetPropertyCallbackEx setPropertyEx = jsClass->version == 1000 ? jsClass->v1000.setPropertyEx : nullptr;
+
+            if (setProperty || setPropertyEx) {
                 if (!propertyNameRef)
                     propertyNameRef = OpaqueJSString::tryCreate(name);
                 JSValueRef exception = 0;
                 bool result;
                 {
                     JSLock::DropAllLocks dropAllLocks(exec);
-                    result = setProperty(ctx, thisRef, propertyNameRef.get(), valueRef, &exception);
+                    result = setProperty ? setProperty(ctx, thisRef, propertyNameRef.get(), valueRef, &exception) :
+                        setPropertyEx(ctx, jsClass, thisRef, propertyNameRef.get(), valueRef, &exception);
                 }
                 if (exception)
                     throwException(exec, scope, toJS(exec, exception));
@@ -274,21 +312,26 @@ bool JSCallbackObject<Parent>::put(JSCell* cell, ExecState* exec, PropertyName p
                     return result;
             }
             
+            
             if (OpaqueJSClassStaticValuesTable* staticValues = jsClass->staticValues(exec)) {
                 if (StaticValueEntry* entry = staticValues->get(name)) {
                     if (entry->attributes & kJSPropertyAttributeReadOnly)
                         return false;
-                    if (JSObjectSetPropertyCallback setProperty = entry->setProperty) {
-                        JSValueRef exception = 0;
-                        bool result;
-                        {
-                            JSLock::DropAllLocks dropAllLocks(exec);
-                            result = setProperty(ctx, thisRef, entry->propertyNameRef.get(), valueRef, &exception);
+
+                    if ((entry->version == 0 && setProperty) || (entry->version == 1000 && setPropertyEx)) {
+                        if (JSObjectSetPropertyCallback setProperty = entry->v0.setProperty) {
+                            JSValueRef exception = 0;
+                            bool result;
+                            {
+                                JSLock::DropAllLocks dropAllLocks(exec);
+                                result = setProperty ? setProperty(ctx, thisRef, entry->propertyNameRef.get(), valueRef, &exception) :
+                                    setPropertyEx(ctx, jsClass, thisRef, entry->propertyNameRef.get(), valueRef, &exception);
+                            }
+                            if (exception)
+                                throwException(exec, scope, toJS(exec, exception));
+                            if (result || exception)
+                                return result;
                         }
-                        if (exception)
-                            throwException(exec, scope, toJS(exec, exception));
-                        if (result || exception)
-                            return result;
                     }
                 }
             }
@@ -323,14 +366,18 @@ bool JSCallbackObject<Parent>::putByIndex(JSCell* cell, ExecState* exec, unsigne
     Identifier propertyName = Identifier::from(exec, propertyIndex);
 
     for (JSClassRef jsClass = thisObject->classRef(); jsClass; jsClass = jsClass->parentClass) {
-        if (JSObjectSetPropertyCallback setProperty = jsClass->setProperty) {
+        JSObjectSetPropertyCallback setProperty = jsClass->version == 0 ? jsClass->v0.setProperty : nullptr;
+        JSObjectSetPropertyCallbackEx setPropertyEx = jsClass->version == 1000 ? jsClass->v1000.setPropertyEx : nullptr;
+
+        if (setProperty || setPropertyEx) {
             if (!propertyNameRef)
                 propertyNameRef = OpaqueJSString::tryCreate(propertyName.impl());
             JSValueRef exception = 0;
             bool result;
             {
                 JSLock::DropAllLocks dropAllLocks(exec);
-                result = setProperty(ctx, thisRef, propertyNameRef.get(), valueRef, &exception);
+                result = setProperty ? setProperty(ctx, thisRef, propertyNameRef.get(), valueRef, &exception) :
+                    setPropertyEx(ctx, jsClass, thisRef, propertyNameRef.get(), valueRef, &exception);
             }
             if (exception)
                 throwException(exec, scope, toJS(exec, exception));
@@ -342,12 +389,14 @@ bool JSCallbackObject<Parent>::putByIndex(JSCell* cell, ExecState* exec, unsigne
             if (StaticValueEntry* entry = staticValues->get(propertyName.impl())) {
                 if (entry->attributes & kJSPropertyAttributeReadOnly)
                     return false;
-                if (JSObjectSetPropertyCallback setProperty = entry->setProperty) {
+
+                if ((entry->version == 0 && setProperty) || (entry->version == 1000 && setPropertyEx)) {
                     JSValueRef exception = 0;
                     bool result;
                     {
                         JSLock::DropAllLocks dropAllLocks(exec);
-                        result = setProperty(ctx, thisRef, entry->propertyNameRef.get(), valueRef, &exception);
+                        result = setProperty ? setProperty(ctx, thisRef, entry->propertyNameRef.get(), valueRef, &exception) :
+                            setPropertyEx(ctx, jsClass, thisRef, propertyNameRef.get(), valueRef, &exception);
                     }
                     if (exception)
                         throwException(exec, scope, toJS(exec, exception));
@@ -382,20 +431,25 @@ bool JSCallbackObject<Parent>::deleteProperty(JSCell* cell, ExecState* exec, Pro
     
     if (StringImpl* name = propertyName.uid()) {
         for (JSClassRef jsClass = thisObject->classRef(); jsClass; jsClass = jsClass->parentClass) {
-            if (JSObjectDeletePropertyCallback deleteProperty = jsClass->deleteProperty) {
+            JSObjectDeletePropertyCallback deleteProperty = jsClass->version == 0 ? jsClass->v0.deleteProperty : nullptr;
+            JSObjectDeletePropertyCallbackEx deletePropertyEx = jsClass->version == 1000 ? jsClass->v1000.deletePropertyEx : nullptr;
+
+            if (deleteProperty || deletePropertyEx) {
                 if (!propertyNameRef)
                     propertyNameRef = OpaqueJSString::tryCreate(name);
                 JSValueRef exception = 0;
                 bool result;
                 {
                     JSLock::DropAllLocks dropAllLocks(exec);
-                    result = deleteProperty(ctx, thisRef, propertyNameRef.get(), &exception);
+                    result = deleteProperty ? deleteProperty(ctx, thisRef, propertyNameRef.get(), &exception) :
+                        deletePropertyEx(ctx, jsClass, thisRef, propertyNameRef.get(), &exception);
                 }
                 if (exception)
                     throwException(exec, scope, toJS(exec, exception));
                 if (result || exception)
                     return true;
             }
+            
             
             if (OpaqueJSClassStaticValuesTable* staticValues = jsClass->staticValues(exec)) {
                 if (StaticValueEntry* entry = staticValues->get(name)) {
@@ -430,7 +484,7 @@ ConstructType JSCallbackObject<Parent>::getConstructData(JSCell* cell, Construct
 {
     JSCallbackObject* thisObject = jsCast<JSCallbackObject*>(cell);
     for (JSClassRef jsClass = thisObject->classRef(); jsClass; jsClass = jsClass->parentClass) {
-        if (jsClass->callAsConstructor) {
+        if ((jsClass->version == 0 && jsClass->v0.callAsConstructor) || (jsClass->version == 1000 && jsClass->v1000.callAsConstructorEx)) {
             constructData.native.function = construct;
             return ConstructType::Host;
         }
@@ -449,7 +503,10 @@ EncodedJSValue JSCallbackObject<Parent>::construct(ExecState* exec)
     JSObjectRef constructorRef = toRef(constructor);
     
     for (JSClassRef jsClass = jsCast<JSCallbackObject<Parent>*>(constructor)->classRef(); jsClass; jsClass = jsClass->parentClass) {
-        if (JSObjectCallAsConstructorCallback callAsConstructor = jsClass->callAsConstructor) {
+        JSObjectCallAsConstructorCallback callAsConstructor = jsClass->version == 0 ? jsClass->v0.callAsConstructor : nullptr;
+        JSObjectCallAsConstructorCallbackEx callAsConstructorEx = jsClass->version == 1000 ? jsClass->v1000.callAsConstructorEx : nullptr;
+
+        if (callAsConstructor || callAsConstructorEx) {
             size_t argumentCount = exec->argumentCount();
             Vector<JSValueRef, 16> arguments;
             arguments.reserveInitialCapacity(argumentCount);
@@ -459,12 +516,13 @@ EncodedJSValue JSCallbackObject<Parent>::construct(ExecState* exec)
             JSObject* result;
             {
                 JSLock::DropAllLocks dropAllLocks(exec);
-                result = toJS(callAsConstructor(execRef, constructorRef, argumentCount, arguments.data(), &exception));
+                result = toJS(callAsConstructor ? callAsConstructor(execRef, constructorRef, argumentCount, arguments.data(), &exception) :
+                    callAsConstructorEx(execRef, jsClass, constructorRef, argumentCount, arguments.data(), &exception));
             }
             if (exception)
                 throwException(exec, scope, toJS(exec, exception));
             return JSValue::encode(result);
-        }
+        }  
     }
     
     RELEASE_ASSERT_NOT_REACHED(); // getConstructData should prevent us from reaching here
@@ -482,13 +540,17 @@ bool JSCallbackObject<Parent>::customHasInstance(JSObject* object, ExecState* ex
     JSObjectRef thisRef = toRef(thisObject);
     
     for (JSClassRef jsClass = thisObject->classRef(); jsClass; jsClass = jsClass->parentClass) {
-        if (JSObjectHasInstanceCallback hasInstance = jsClass->hasInstance) {
+        JSObjectHasInstanceCallback hasInstance = jsClass->version == 0 ? jsClass->v0.hasInstance : nullptr;
+        JSObjectHasInstanceCallbackEx hasInstanceEx = jsClass->version == 1000 ? jsClass->v1000.hasInstanceEx : nullptr;
+
+        if (hasInstance || hasInstanceEx) {
             JSValueRef valueRef = toRef(exec, value);
             JSValueRef exception = 0;
             bool result;
             {
                 JSLock::DropAllLocks dropAllLocks(exec);
-                result = hasInstance(execRef, thisRef, valueRef, &exception);
+                result = hasInstance ? hasInstance(execRef, thisRef, valueRef, &exception) :
+                    hasInstanceEx(execRef, jsClass, thisRef, valueRef, &exception);
             }
             if (exception)
                 throwException(exec, scope, toJS(exec, exception));
@@ -503,7 +565,7 @@ CallType JSCallbackObject<Parent>::getCallData(JSCell* cell, CallData& callData)
 {
     JSCallbackObject* thisObject = jsCast<JSCallbackObject*>(cell);
     for (JSClassRef jsClass = thisObject->classRef(); jsClass; jsClass = jsClass->parentClass) {
-        if (jsClass->callAsFunction) {
+        if ((jsClass->version == 0 && jsClass->v0.callAsFunction) || (jsClass->version == 1000 && jsClass->v1000.callAsFunctionEx)) {
             callData.native.function = call;
             return CallType::Host;
         }
@@ -522,7 +584,10 @@ EncodedJSValue JSCallbackObject<Parent>::call(ExecState* exec)
     JSObjectRef thisObjRef = toRef(jsCast<JSObject*>(exec->thisValue().toThis(exec, NotStrictMode)));
     
     for (JSClassRef jsClass = jsCast<JSCallbackObject<Parent>*>(toJS(functionRef))->classRef(); jsClass; jsClass = jsClass->parentClass) {
-        if (JSObjectCallAsFunctionCallback callAsFunction = jsClass->callAsFunction) {
+        JSObjectCallAsFunctionCallback callAsFunction = jsClass->version == 0 ? jsClass->v0.callAsFunction : nullptr;
+        JSObjectCallAsFunctionCallbackEx callAsFunctionEx = jsClass->version == 1000 ? jsClass->v1000.callAsFunctionEx : nullptr;
+
+        if (callAsFunction || callAsFunctionEx) {
             size_t argumentCount = exec->argumentCount();
             Vector<JSValueRef, 16> arguments;
             arguments.reserveInitialCapacity(argumentCount);
@@ -532,7 +597,8 @@ EncodedJSValue JSCallbackObject<Parent>::call(ExecState* exec)
             JSValue result;
             {
                 JSLock::DropAllLocks dropAllLocks(exec);
-                result = toJS(exec, callAsFunction(execRef, functionRef, thisObjRef, argumentCount, arguments.data(), &exception));
+                result = toJS(exec, callAsFunction ? callAsFunction(execRef, functionRef, thisObjRef, argumentCount, arguments.data(), &exception) :
+                    callAsFunctionEx(execRef, jsClass, functionRef, thisObjRef, argumentCount, arguments.data(), &exception));
             }
             if (exception)
                 throwException(exec, scope, toJS(exec, exception));
@@ -552,9 +618,13 @@ void JSCallbackObject<Parent>::getOwnNonIndexPropertyNames(JSObject* object, Exe
     JSObjectRef thisRef = toRef(thisObject);
     
     for (JSClassRef jsClass = thisObject->classRef(); jsClass; jsClass = jsClass->parentClass) {
-        if (JSObjectGetPropertyNamesCallback getPropertyNames = jsClass->getPropertyNames) {
+        if (jsClass->version == 0 && jsClass->v0.getPropertyNames) {
             JSLock::DropAllLocks dropAllLocks(exec);
-            getPropertyNames(execRef, thisRef, toRef(&propertyNames));
+            jsClass->v0.getPropertyNames(execRef, thisRef, toRef(&propertyNames));
+        } else if(jsClass->version == 1000 && jsClass->v1000.getPropertyNamesEx)
+        {
+            JSLock::DropAllLocks dropAllLocks(exec);
+            jsClass->v1000.getPropertyNamesEx(execRef, jsClass, thisRef, toRef(&propertyNames));
         }
         
         if (OpaqueJSClassStaticValuesTable* staticValues = jsClass->staticValues(exec)) {
@@ -563,10 +633,12 @@ void JSCallbackObject<Parent>::getOwnNonIndexPropertyNames(JSObject* object, Exe
             for (iterator it = staticValues->begin(); it != end; ++it) {
                 StringImpl* name = it->key.get();
                 StaticValueEntry* entry = it->value.get();
-                if (entry->getProperty && (!(entry->attributes & kJSPropertyAttributeDontEnum) || mode.includeDontEnumProperties())) {
-                    ASSERT(!name->isSymbol());
-                    propertyNames.add(Identifier::fromString(exec, String(name)));
-                }
+
+               if (((entry->version == 0 && entry->v0.getProperty) || (entry->version == 1000 && entry->v1000.getPropertyEx))
+                   && (!(entry->attributes & kJSPropertyAttributeDontEnum) || mode.includeDontEnumProperties())) {
+                   ASSERT(!name->isSymbol());
+                   propertyNames.add(Identifier::fromString(exec, String(name)));
+               }
             }
         }
         
@@ -576,6 +648,7 @@ void JSCallbackObject<Parent>::getOwnNonIndexPropertyNames(JSObject* object, Exe
             for (iterator it = staticFunctions->begin(); it != end; ++it) {
                 StringImpl* name = it->key.get();
                 StaticFunctionEntry* entry = it->value.get();
+
                 if (!(entry->attributes & kJSPropertyAttributeDontEnum) || mode.includeDontEnumProperties()) {
                     ASSERT(!name->isSymbol());
                     propertyNames.add(Identifier::fromString(exec, String(name)));
@@ -621,12 +694,16 @@ JSValue JSCallbackObject<Parent>::getStaticValue(ExecState* exec, PropertyName p
         for (JSClassRef jsClass = classRef(); jsClass; jsClass = jsClass->parentClass) {
             if (OpaqueJSClassStaticValuesTable* staticValues = jsClass->staticValues(exec)) {
                 if (StaticValueEntry* entry = staticValues->get(name)) {
-                    if (JSObjectGetPropertyCallback getProperty = entry->getProperty) {
+                    JSObjectGetPropertyCallback getProperty = entry->version == 0 ? entry->v0.getProperty : nullptr;
+                    JSObjectGetPropertyCallbackEx getPropertyEx = entry->version == 1000 ? entry->v1000.getPropertyEx : nullptr;
+
+                    if (getProperty || getPropertyEx) {
                         JSValueRef exception = 0;
                         JSValueRef value;
                         {
                             JSLock::DropAllLocks dropAllLocks(exec);
-                            value = getProperty(toRef(exec), thisRef, entry->propertyNameRef.get(), &exception);
+                            value = getProperty ? getProperty(toRef(exec), thisRef, entry->propertyNameRef.get(), &exception) :
+                                getPropertyEx(toRef(exec), jsClass, thisRef, entry->propertyNameRef.get(), &exception);
                         }
                         if (exception) {
                             throwException(exec, scope, toJS(exec, exception));
@@ -660,8 +737,13 @@ EncodedJSValue JSCallbackObject<Parent>::staticFunctionGetter(ExecState* exec, E
         for (JSClassRef jsClass = thisObj->classRef(); jsClass; jsClass = jsClass->parentClass) {
             if (OpaqueJSClassStaticFunctionsTable* staticFunctions = jsClass->staticFunctions(exec)) {
                 if (StaticFunctionEntry* entry = staticFunctions->get(name)) {
-                    if (JSObjectCallAsFunctionCallback callAsFunction = entry->callAsFunction) {
-                        JSObject* o = JSCallbackFunction::create(vm, thisObj->globalObject(vm), callAsFunction, name);
+                    if (entry->version == 0 && entry->v0.callAsFunction) {
+                        JSObject* o = JSCallbackFunction::create(vm, thisObj->globalObject(vm), entry->v0.callAsFunction, name);
+                        thisObj->putDirect(vm, propertyName, o, entry->attributes);
+                        return JSValue::encode(o);
+                    } else if(entry->version == 1000 && entry->v1000.callAsFunctionEx)
+                    {
+                        JSObject* o = JSCallbackFunction::create(vm, thisObj->globalObject(vm), jsClass, entry->v1000.callAsFunctionEx, name);
                         thisObj->putDirect(vm, propertyName, o, entry->attributes);
                         return JSValue::encode(o);
                     }
@@ -686,14 +768,18 @@ EncodedJSValue JSCallbackObject<Parent>::callbackGetter(ExecState* exec, Encoded
     
     if (StringImpl* name = propertyName.uid()) {
         for (JSClassRef jsClass = thisObj->classRef(); jsClass; jsClass = jsClass->parentClass) {
-            if (JSObjectGetPropertyCallback getProperty = jsClass->getProperty) {
+            JSObjectGetPropertyCallback getProperty = jsClass->version == 0 ? jsClass->v0.getProperty : nullptr;
+            JSObjectGetPropertyCallbackEx getPropertyEx = jsClass->version == 1000 ? jsClass->v1000.getPropertyEx : nullptr;
+
+            if (getProperty || getPropertyEx) {
                 if (!propertyNameRef)
                     propertyNameRef = OpaqueJSString::tryCreate(name);
                 JSValueRef exception = 0;
                 JSValueRef value;
                 {
                     JSLock::DropAllLocks dropAllLocks(exec);
-                    value = getProperty(toRef(exec), thisRef, propertyNameRef.get(), &exception);
+                    value = getProperty ? getProperty(toRef(exec), thisRef, propertyNameRef.get(), &exception) :
+                        getPropertyEx(toRef(exec), jsClass, thisRef, propertyNameRef.get(), &exception);
                 }
                 if (exception) {
                     throwException(exec, scope, toJS(exec, exception));

--- a/Source/JavaScriptCore/API/JSCallbackObjectFunctions.h
+++ b/Source/JavaScriptCore/API/JSCallbackObjectFunctions.h
@@ -734,7 +734,7 @@ EncodedJSValue JSCallbackObject<Parent>::staticFunctionGetter(ExecState* exec, E
                         return JSValue::encode(o);
                     } else if(entry->version == 1000 && entry->v1000.callAsFunctionEx)
                     {
-                        JSObject* o = JSCallbackFunction::create(vm, thisObj->globalObject(vm), entry->v1000.owner, entry->v1000.callAsFunctionEx, name);
+                        JSObject* o = JSCallbackFunction::create(vm, thisObj->globalObject(vm), jsClass->prototypeForClass ? jsClass->prototypeForClass : jsClass, entry->v1000.callAsFunctionEx, name);
                         thisObj->putDirect(vm, propertyName, o, entry->attributes);
                         return JSValue::encode(o);
                     }

--- a/Source/JavaScriptCore/API/JSClassRef.cpp
+++ b/Source/JavaScriptCore/API/JSClassRef.cpp
@@ -173,6 +173,7 @@ Ref<OpaqueJSClass> OpaqueJSClass::create(const JSClassDefinition* clientDefiniti
 
     JSClassDefinition protoDefinition = kJSClassDefinitionEmpty;
     protoDefinition.finalize = 0;
+    protoDefinition.version = clientDefinition->version;
     std::swap(definition.staticFunctions, protoDefinition.staticFunctions); // Move static functions to the prototype.
 
     // We are supposed to use JSClassRetain/Release but since we know that we currently have

--- a/Source/JavaScriptCore/API/JSClassRef.cpp
+++ b/Source/JavaScriptCore/API/JSClassRef.cpp
@@ -38,7 +38,7 @@
 
 using namespace JSC;
 
-const JSClassDefinition kJSClassDefinitionEmpty = {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
+const JSClassDefinition kJSClassDefinitionEmpty = { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 };
 
 OpaqueJSClass::OpaqueJSClass(const JSClassDefinition* definition, OpaqueJSClass* protoClass)
     : parentClass(definition->parentClass)
@@ -76,7 +76,8 @@ OpaqueJSClass::OpaqueJSClass(const JSClassDefinition* definition, OpaqueJSClass*
             definition->callAsFunctionEx,
             definition->callAsConstructorEx,
             definition->hasInstanceEx,
-            definition->convertToTypeEx
+            definition->convertToTypeEx,
+            definition->privateData
         };
     }
 

--- a/Source/JavaScriptCore/API/JSClassRef.cpp
+++ b/Source/JavaScriptCore/API/JSClassRef.cpp
@@ -38,46 +38,100 @@
 
 using namespace JSC;
 
-const JSClassDefinition kJSClassDefinitionEmpty = { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 };
+const JSClassDefinition kJSClassDefinitionEmpty = {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
 
-OpaqueJSClass::OpaqueJSClass(const JSClassDefinition* definition, OpaqueJSClass* protoClass) 
+OpaqueJSClass::OpaqueJSClass(const JSClassDefinition* definition, OpaqueJSClass* protoClass)
     : parentClass(definition->parentClass)
-    , prototypeClass(0)
-    , initialize(definition->initialize)
-    , finalize(definition->finalize)
-    , hasProperty(definition->hasProperty)
-    , getProperty(definition->getProperty)
-    , setProperty(definition->setProperty)
-    , deleteProperty(definition->deleteProperty)
-    , getPropertyNames(definition->getPropertyNames)
-    , callAsFunction(definition->callAsFunction)
-    , callAsConstructor(definition->callAsConstructor)
-    , hasInstance(definition->hasInstance)
-    , convertToType(definition->convertToType)
-    , m_className(String::fromUTF8(definition->className))
+      , prototypeClass(0)
+      , version(definition->version)
+      , m_className(String::fromUTF8(definition->className))
 {
+    ASSERT(version == 0 || version == 1000);
+
+    if (version == 0)
+    {
+        v0 = {
+            definition->initialize,
+            definition->finalize,
+            definition->hasProperty,
+            definition->getProperty,
+            definition->setProperty,
+            definition->deleteProperty,
+            definition->getPropertyNames,
+            definition->callAsFunction,
+            definition->callAsConstructor,
+            definition->hasInstance,
+            definition->convertToType
+        };
+    } else if (version == 1000)
+    {
+        v1000 = {
+            definition->initializeEx,
+            definition->finalizeEx,
+            definition->hasPropertyEx,
+            definition->getPropertyEx,
+            definition->setPropertyEx,
+            definition->deletePropertyEx,
+            definition->getPropertyNamesEx,
+            definition->callAsFunctionEx,
+            definition->callAsConstructorEx,
+            definition->hasInstanceEx,
+            definition->convertToTypeEx
+        };
+    }
+
     initializeThreading();
 
-    if (const JSStaticValue* staticValue = definition->staticValues) {
+    if (const JSStaticValue* staticValue = definition->staticValues)
+    {
         m_staticValues = std::make_unique<OpaqueJSClassStaticValuesTable>();
-        while (staticValue->name) {
+        while (staticValue->name)
+        {
             String valueName = String::fromUTF8(staticValue->name);
-            if (!valueName.isNull())
-                m_staticValues->set(valueName.impl(), std::make_unique<StaticValueEntry>(staticValue->getProperty, staticValue->setProperty, staticValue->attributes, valueName));
+            if (!valueName.isNull()) {
+                if (version == 0) {
+                    m_staticValues->set(valueName.impl(),
+                        std::make_unique<StaticValueEntry>(staticValue->getProperty,
+                            staticValue->setProperty,
+                            staticValue->attributes, valueName));
+                }
+                else if (version == 1000)
+                {
+                    m_staticValues->set(valueName.impl(),
+                        std::make_unique<StaticValueEntry>(staticValue->getPropertyEx,
+                            staticValue->setPropertyEx,
+                            staticValue->attributes,
+                            valueName));
+                }
+            }
+
             ++staticValue;
         }
     }
 
-    if (const JSStaticFunction* staticFunction = definition->staticFunctions) {
+    if (const JSStaticFunction* staticFunction = definition->staticFunctions)
+    {
         m_staticFunctions = std::make_unique<OpaqueJSClassStaticFunctionsTable>();
-        while (staticFunction->name) {
+        while (staticFunction->name)
+        {
             String functionName = String::fromUTF8(staticFunction->name);
-            if (!functionName.isNull())
-                m_staticFunctions->set(functionName.impl(), std::make_unique<StaticFunctionEntry>(staticFunction->callAsFunction, staticFunction->attributes));
+            if (!functionName.isNull()) {
+                if(version == 0)
+                {
+                    m_staticFunctions->set(functionName.impl(),
+                        std::make_unique<StaticFunctionEntry>(
+                            staticFunction->callAsFunction, staticFunction->attributes));
+                } else if(version == 1000)
+                {
+                    m_staticFunctions->set(functionName.impl(), 
+                        std::make_unique<StaticFunctionEntry>(
+                            staticFunction->callAsFunctionEx, staticFunction->attributes));
+                }
+            }
             ++staticFunction;
         }
     }
-        
+
     if (protoClass)
         prototypeClass = JSClassRetain(protoClass);
 }
@@ -88,19 +142,21 @@ OpaqueJSClass::~OpaqueJSClass()
     ASSERT(!m_className.length() || !m_className.impl()->isAtom());
 
 #ifndef NDEBUG
-    if (m_staticValues) {
+    if (m_staticValues)
+    {
         OpaqueJSClassStaticValuesTable::const_iterator end = m_staticValues->end();
         for (OpaqueJSClassStaticValuesTable::const_iterator it = m_staticValues->begin(); it != end; ++it)
             ASSERT(!it->key->isAtom());
     }
 
-    if (m_staticFunctions) {
+    if (m_staticFunctions)
+    {
         OpaqueJSClassStaticFunctionsTable::const_iterator end = m_staticFunctions->end();
         for (OpaqueJSClassStaticFunctionsTable::const_iterator it = m_staticFunctions->begin(); it != end; ++it)
             ASSERT(!it->key->isAtom());
     }
 #endif
-    
+
     if (prototypeClass)
         JSClassRelease(prototypeClass);
 }
@@ -117,7 +173,7 @@ Ref<OpaqueJSClass> OpaqueJSClass::create(const JSClassDefinition* clientDefiniti
     JSClassDefinition protoDefinition = kJSClassDefinitionEmpty;
     protoDefinition.finalize = 0;
     std::swap(definition.staticFunctions, protoDefinition.staticFunctions); // Move static functions to the prototype.
-    
+
     // We are supposed to use JSClassRetain/Release but since we know that we currently have
     // the only reference to this class object we cheat and use a RefPtr instead.
     RefPtr<OpaqueJSClass> protoClass = adoptRef(new OpaqueJSClass(&protoDefinition, 0));
@@ -127,29 +183,37 @@ Ref<OpaqueJSClass> OpaqueJSClass::create(const JSClassDefinition* clientDefiniti
 OpaqueJSClassContextData::OpaqueJSClassContextData(JSC::VM&, OpaqueJSClass* jsClass)
     : m_class(jsClass)
 {
-    if (jsClass->m_staticValues) {
+    if (jsClass->m_staticValues)
+    {
         staticValues = std::make_unique<OpaqueJSClassStaticValuesTable>();
         OpaqueJSClassStaticValuesTable::const_iterator end = jsClass->m_staticValues->end();
-        for (OpaqueJSClassStaticValuesTable::const_iterator it = jsClass->m_staticValues->begin(); it != end; ++it) {
+        for (OpaqueJSClassStaticValuesTable::const_iterator it = jsClass->m_staticValues->begin(); it != end; ++it)
+        {
             ASSERT(!it->key->isAtom());
             String valueName = it->key->isolatedCopy();
-            staticValues->add(valueName.impl(), std::make_unique<StaticValueEntry>(it->value->getProperty, it->value->setProperty, it->value->attributes, valueName));
+
+            staticValues->add(valueName.impl(), std::make_unique<StaticValueEntry>(*it->value, valueName));
         }
     }
 
-    if (jsClass->m_staticFunctions) {
+    if (jsClass->m_staticFunctions)
+    {
         staticFunctions = std::make_unique<OpaqueJSClassStaticFunctionsTable>();
         OpaqueJSClassStaticFunctionsTable::const_iterator end = jsClass->m_staticFunctions->end();
-        for (OpaqueJSClassStaticFunctionsTable::const_iterator it = jsClass->m_staticFunctions->begin(); it != end; ++it) {
+        for (OpaqueJSClassStaticFunctionsTable::const_iterator it = jsClass->m_staticFunctions->begin(); it != end; ++it
+        )
+        {
             ASSERT(!it->key->isAtom());
-            staticFunctions->add(it->key->isolatedCopy(), std::make_unique<StaticFunctionEntry>(it->value->callAsFunction, it->value->attributes));
+            staticFunctions->add(it->key->isolatedCopy(), std::make_unique<StaticFunctionEntry>(*it->value));
         }
     }
 }
 
 OpaqueJSClassContextData& OpaqueJSClass::contextData(ExecState* exec)
 {
-    std::unique_ptr<OpaqueJSClassContextData>& contextData = exec->lexicalGlobalObject()->opaqueJSClassData().add(this, nullptr).iterator->value;
+    std::unique_ptr<OpaqueJSClassContextData>& contextData = exec
+                                                             ->lexicalGlobalObject()->opaqueJSClassData().add(
+                                                                 this, nullptr).iterator->value;
     if (!contextData)
         contextData = std::make_unique<OpaqueJSClassContextData>(exec->vm(), this);
     return *contextData;
@@ -190,8 +254,11 @@ JSObject* OpaqueJSClass::prototype(ExecState* exec)
         return prototype;
 
     // Recursive, but should be good enough for our purposes
-    JSObject* prototype = JSCallbackObject<JSDestructibleObject>::create(exec, exec->lexicalGlobalObject(), exec->lexicalGlobalObject()->callbackObjectStructure(), prototypeClass, &jsClassData); // set jsClassData as the object's private data, so it can clear our reference on destruction
-    if (parentClass) {
+    JSObject* prototype = JSCallbackObject<JSDestructibleObject>::create(
+        exec, exec->lexicalGlobalObject(), exec->lexicalGlobalObject()->callbackObjectStructure(), prototypeClass,
+        &jsClassData); // set jsClassData as the object's private data, so it can clear our reference on destruction
+    if (parentClass)
+    {
         if (JSObject* parentPrototype = parentClass->prototype(exec))
             prototype->setPrototypeDirect(exec->vm(), parentPrototype);
     }

--- a/Source/JavaScriptCore/API/JSClassRef.cpp
+++ b/Source/JavaScriptCore/API/JSClassRef.cpp
@@ -126,7 +126,7 @@ OpaqueJSClass::OpaqueJSClass(const JSClassDefinition* definition, OpaqueJSClass*
                 {
                     m_staticFunctions->set(functionName.impl(), 
                         std::make_unique<StaticFunctionEntry>(
-                            staticFunction->callAsFunctionEx, staticFunction->attributes));
+                            staticFunction->callAsFunctionEx, staticFunction->attributes, this));
                 }
             }
             ++staticFunction;

--- a/Source/JavaScriptCore/API/JSClassRef.h
+++ b/Source/JavaScriptCore/API/JSClassRef.h
@@ -88,17 +88,18 @@ public:
     {
     }
 
-    StaticFunctionEntry(JSObjectCallAsFunctionCallbackEx _callAsFunction, JSPropertyAttributes _attributes)
-        : version(1000), v1000{ _callAsFunction }, attributes(_attributes)
+    StaticFunctionEntry(JSObjectCallAsFunctionCallbackEx _callAsFunction, JSPropertyAttributes _attributes, JSClassRef owner)
+        : version(1000), v1000{ _callAsFunction, owner }, attributes(_attributes)
     {
     }
 
     StaticFunctionEntry(const StaticFunctionEntry& other) : version(other.version), attributes(other.attributes)
     {
-        if(version == 0)
+        if (version == 0)
         {
             v0 = other.v0;
-        } else if(version == 1000)
+        }
+        else if (version == 1000)
         {
             v1000 = other.v1000;
         }
@@ -107,12 +108,15 @@ public:
     int version;
 
     union {
-        struct{
+        struct {
             JSObjectCallAsFunctionCallback callAsFunction;
         } v0;
 
         struct {
             JSObjectCallAsFunctionCallbackEx callAsFunctionEx;
+            // Static functions are called on their prototype, but thats not the class they really belong to.
+            // To be able to resolve the class they have been created on, there is a pointer to it
+            JSClassRef owner;
         } v1000;
     };
     JSPropertyAttributes attributes;

--- a/Source/JavaScriptCore/API/JSClassRef.h
+++ b/Source/JavaScriptCore/API/JSClassRef.h
@@ -37,15 +37,45 @@ struct StaticValueEntry {
     WTF_MAKE_FAST_ALLOCATED;
 public:
     StaticValueEntry(JSObjectGetPropertyCallback _getProperty, JSObjectSetPropertyCallback _setProperty, JSPropertyAttributes _attributes, String& propertyName)
-        : getProperty(_getProperty)
-        , setProperty(_setProperty)
+        : version(0)
+        , v0{ _getProperty, _setProperty }
         , attributes(_attributes)
         , propertyNameRef(OpaqueJSString::tryCreate(propertyName))
     {
     }
-    
-    JSObjectGetPropertyCallback getProperty;
-    JSObjectSetPropertyCallback setProperty;
+
+    StaticValueEntry(JSObjectGetPropertyCallbackEx _getPropertyEx, JSObjectSetPropertyCallbackEx _setPropertyEx, JSPropertyAttributes _attributes, String& propertyName)
+        : version(1000)
+        , v1000{ _getPropertyEx, _setPropertyEx }
+        , attributes(_attributes)
+        , propertyNameRef(OpaqueJSString::tryCreate(propertyName))
+    {
+    }
+
+    StaticValueEntry(const StaticValueEntry& other, String& valueName) : version(other.version), attributes(other.attributes), propertyNameRef(OpaqueJSString::tryCreate(valueName))
+    {
+        if(version == 0)
+        {
+            v0 = other.v0;
+        } else if (version == 1000)
+        {
+            v1000 = other.v1000;
+        }
+    }
+
+    int version;
+
+    union {
+        struct {
+            JSObjectGetPropertyCallback getProperty;
+            JSObjectSetPropertyCallback setProperty;
+        } v0;
+
+        struct {
+            JSObjectGetPropertyCallbackEx getPropertyEx;
+            JSObjectSetPropertyCallbackEx setPropertyEx;
+        } v1000;
+    };
     JSPropertyAttributes attributes;
     RefPtr<OpaqueJSString> propertyNameRef;
 };
@@ -54,11 +84,37 @@ struct StaticFunctionEntry {
     WTF_MAKE_FAST_ALLOCATED;
 public:
     StaticFunctionEntry(JSObjectCallAsFunctionCallback _callAsFunction, JSPropertyAttributes _attributes)
-        : callAsFunction(_callAsFunction), attributes(_attributes)
+        : version(0), v0{ _callAsFunction }, attributes(_attributes)
     {
     }
 
-    JSObjectCallAsFunctionCallback callAsFunction;
+    StaticFunctionEntry(JSObjectCallAsFunctionCallbackEx _callAsFunction, JSPropertyAttributes _attributes)
+        : version(1000), v1000{ _callAsFunction }, attributes(_attributes)
+    {
+    }
+
+    StaticFunctionEntry(const StaticFunctionEntry& other) : version(other.version), attributes(other.attributes)
+    {
+        if(version == 0)
+        {
+            v0 = other.v0;
+        } else if(version == 1000)
+        {
+            v1000 = other.v1000;
+        }
+    }
+
+    int version;
+
+    union {
+        struct{
+            JSObjectCallAsFunctionCallback callAsFunction;
+        } v0;
+
+        struct {
+            JSObjectCallAsFunctionCallbackEx callAsFunctionEx;
+        } v1000;
+    };
     JSPropertyAttributes attributes;
 };
 
@@ -99,18 +155,40 @@ struct OpaqueJSClass : public ThreadSafeRefCounted<OpaqueJSClass> {
 
     OpaqueJSClass* parentClass;
     OpaqueJSClass* prototypeClass;
-    
-    JSObjectInitializeCallback initialize;
-    JSObjectFinalizeCallback finalize;
-    JSObjectHasPropertyCallback hasProperty;
-    JSObjectGetPropertyCallback getProperty;
-    JSObjectSetPropertyCallback setProperty;
-    JSObjectDeletePropertyCallback deleteProperty;
-    JSObjectGetPropertyNamesCallback getPropertyNames;
-    JSObjectCallAsFunctionCallback callAsFunction;
-    JSObjectCallAsConstructorCallback callAsConstructor;
-    JSObjectHasInstanceCallback hasInstance;
-    JSObjectConvertToTypeCallback convertToType;
+
+    int version;
+
+    union {
+        struct
+        {
+            JSObjectInitializeCallback initialize;
+            JSObjectFinalizeCallback finalize;
+            JSObjectHasPropertyCallback hasProperty;
+            JSObjectGetPropertyCallback getProperty;
+            JSObjectSetPropertyCallback setProperty;
+            JSObjectDeletePropertyCallback deleteProperty;
+            JSObjectGetPropertyNamesCallback getPropertyNames;
+            JSObjectCallAsFunctionCallback callAsFunction;
+            JSObjectCallAsConstructorCallback callAsConstructor;
+            JSObjectHasInstanceCallback hasInstance;
+            JSObjectConvertToTypeCallback convertToType;
+        } v0;
+
+        struct
+        {
+            JSObjectInitializeCallbackEx initializeEx;
+            JSObjectFinalizeCallbackEx finalizeEx;
+            JSObjectHasPropertyCallbackEx hasPropertyEx;
+            JSObjectGetPropertyCallbackEx getPropertyEx;
+            JSObjectSetPropertyCallbackEx setPropertyEx;
+            JSObjectDeletePropertyCallbackEx deletePropertyEx;
+            JSObjectGetPropertyNamesCallbackEx getPropertyNamesEx;
+            JSObjectCallAsFunctionCallbackEx callAsFunctionEx;
+            JSObjectCallAsConstructorCallbackEx callAsConstructorEx;
+            JSObjectHasInstanceCallbackEx hasInstanceEx;
+            JSObjectConvertToTypeCallbackEx convertToTypeEx;
+        } v1000;
+    };
 
 private:
     friend struct OpaqueJSClassContextData;

--- a/Source/JavaScriptCore/API/JSClassRef.h
+++ b/Source/JavaScriptCore/API/JSClassRef.h
@@ -88,8 +88,8 @@ public:
     {
     }
 
-    StaticFunctionEntry(JSObjectCallAsFunctionCallbackEx _callAsFunction, JSPropertyAttributes _attributes, JSClassRef owner)
-        : version(1000), v1000{ _callAsFunction, owner }, attributes(_attributes)
+    StaticFunctionEntry(JSObjectCallAsFunctionCallbackEx _callAsFunction, JSPropertyAttributes _attributes)
+        : version(1000), v1000{ _callAsFunction }, attributes(_attributes)
     {
     }
 
@@ -114,9 +114,6 @@ public:
 
         struct {
             JSObjectCallAsFunctionCallbackEx callAsFunctionEx;
-            // Static functions are called on their prototype, but thats not the class they really belong to.
-            // To be able to resolve the class they have been created on, there is a pointer to it
-            JSClassRef owner;
         } v1000;
     };
     JSPropertyAttributes attributes;
@@ -159,6 +156,7 @@ struct OpaqueJSClass : public ThreadSafeRefCounted<OpaqueJSClass> {
 
     OpaqueJSClass* parentClass;
     OpaqueJSClass* prototypeClass;
+    OpaqueJSClass* prototypeForClass;
 
     int version;
 

--- a/Source/JavaScriptCore/API/JSClassRef.h
+++ b/Source/JavaScriptCore/API/JSClassRef.h
@@ -187,6 +187,8 @@ struct OpaqueJSClass : public ThreadSafeRefCounted<OpaqueJSClass> {
             JSObjectCallAsConstructorCallbackEx callAsConstructorEx;
             JSObjectHasInstanceCallbackEx hasInstanceEx;
             JSObjectConvertToTypeCallbackEx convertToTypeEx;
+
+            void* privateData;
         } v1000;
     };
 

--- a/Source/JavaScriptCore/API/JSObjectRef.cpp
+++ b/Source/JavaScriptCore/API/JSObjectRef.cpp
@@ -84,6 +84,22 @@ void JSClassRelease(JSClassRef jsClass)
     jsClass->deref();
 }
 
+void* JSClassGetPrivate(JSClassRef jsClass)
+{
+    return jsClass->version == 1000 ? jsClass->v1000.privateData : nullptr;
+}
+
+bool JSClassSetPrivate(JSClassRef jsClass, void* data)
+{
+    if(jsClass->version != 1000)
+    {
+        return false;
+    }
+
+    jsClass->v1000.privateData = data;
+    return true;
+}
+
 JSObjectRef JSObjectMake(JSContextRef ctx, JSClassRef jsClass, void* data)
 {
     if (!ctx) {

--- a/Source/JavaScriptCore/API/JSObjectRef.h
+++ b/Source/JavaScriptCore/API/JSObjectRef.h
@@ -247,7 +247,7 @@ If this callback is NULL, calling your object as a function will throw an except
 typedef JSValueRef 
 (*JSObjectCallAsFunctionCallback) (JSContextRef ctx, JSObjectRef function, JSObjectRef thisObject, size_t argumentCount, const JSValueRef arguments[], JSValueRef* exception);
 
-/* Extension of the above callback with the class that the method is being invoked for and the name of the method taht is being invoked. */
+/* Extension of the above callback with the class that the method is being invoked for and the name of the method that is being invoked. */
 typedef JSValueRef
 (*JSObjectCallAsFunctionCallbackEx) (JSContextRef ctx, JSClassRef clazz, JSStringRef methodName, JSObjectRef function, JSObjectRef thisObject, size_t argumentCount, const JSValueRef arguments[], JSValueRef* exception);
 
@@ -486,7 +486,7 @@ JS_EXPORT void* JSClassGetPrivate(JSClassRef jsClass);
 @abstract Sets the private data on a class, only possible with classes created with version 1000 (extended callbacks).
 @param jsClass The class to set the data on
 @param data A void* to set as the private data for the class
-@result true if teh data has been set on the class, false if the class has not been created with version 1000 (extended callbacks)
+@result true if the data has been set on the class, false if the class has not been created with version 1000 (extended callbacks)
 @discussion Only classes with version 1000 (extended callbacks) can store private data, for other classes the function always fails. The set pointer is not touched by the engine.
 */
 JS_EXPORT bool JSClassSetPrivate(JSClassRef jsClass, void* data);

--- a/Source/JavaScriptCore/API/JSObjectRef.h
+++ b/Source/JavaScriptCore/API/JSObjectRef.h
@@ -247,9 +247,9 @@ If this callback is NULL, calling your object as a function will throw an except
 typedef JSValueRef 
 (*JSObjectCallAsFunctionCallback) (JSContextRef ctx, JSObjectRef function, JSObjectRef thisObject, size_t argumentCount, const JSValueRef arguments[], JSValueRef* exception);
 
-/* Extension of the above callback with the class that the method is being invoked for. */
+/* Extension of the above callback with the class that the method is being invoked for and the name of the method taht is being invoked. */
 typedef JSValueRef
-(*JSObjectCallAsFunctionCallbackEx) (JSContextRef ctx, JSClassRef clazz, JSObjectRef function, JSObjectRef thisObject, size_t argumentCount, const JSValueRef arguments[], JSValueRef* exception);
+(*JSObjectCallAsFunctionCallbackEx) (JSContextRef ctx, JSClassRef clazz, JSStringRef methodName, JSObjectRef function, JSObjectRef thisObject, size_t argumentCount, const JSValueRef arguments[], JSValueRef* exception);
 
 
 /*! 

--- a/Source/JavaScriptCore/API/JSObjectRef.h
+++ b/Source/JavaScriptCore/API/JSObjectRef.h
@@ -435,6 +435,8 @@ typedef struct {
             JSObjectConvertToTypeCallbackEx       convertToTypeEx;
         };
     };
+
+    void* privateData; // version 1000
 } JSClassDefinition;
 
 /*! 
@@ -469,6 +471,25 @@ JS_EXPORT JSClassRef JSClassRetain(JSClassRef jsClass);
 @param jsClass The JSClass to release.
 */
 JS_EXPORT void JSClassRelease(JSClassRef jsClass);
+
+/*!
+@function
+@abstract Retrieves the private data from a class reference, only possible with classes created with version 1000 (extended callbacks).
+@param jsClass The class to get the data from
+@result The private data on the class, or NULL, if not set
+@discussion Only classes with version 1000 (extended callbacks) can store private data, for other classes always NULL will always be returned.
+*/
+JS_EXPORT void* JSClassGetPrivate(JSClassRef jsClass);
+
+/*!
+@function
+@abstract Sets the private data on a class, only possible with classes created with version 1000 (extended callbacks).
+@param jsClass The class to set the data on
+@param data A void* to set as the private data for the class
+@result true if teh data has been set on the class, false if the class has not been created with version 1000 (extended callbacks)
+@discussion Only classes with version 1000 (extended callbacks) can store private data, for other classes the function always fails. The set pointer is not touched by the engine.
+*/
+JS_EXPORT bool JSClassSetPrivate(JSClassRef jsClass, void* data);
 
 /*!
 @function


### PR DESCRIPTION
This PR extends WebCore with a new Javascript class version. The version number has been choosen to be 1000 so conflicts with the upstream WebCore can be avoided if apple ever decides to increment the version number.

Features:
- Extended callbacks: version 1000 classes have callbacks which receive a ``JSClassRef`` they are called on
- Private class data: version 1000 classes can store private data

These 2 features are useful when the function pointers for callbacks are not known at compile time. This for example is the case if the callbacks are supplied by code which is called just in time. In such case the callbacks can use the JSClassRef and its private data to delegate to the JIT'ed code.

This PR should still produce source and binary compatible code with previous versions.