### PR TITLE
Fix ambiguous reference error

### DIFF
--- a/Source/JavaScriptCore/tools/JSDollarVM.cpp
+++ b/Source/JavaScriptCore/tools/JSDollarVM.cpp
@@ -176,7 +176,7 @@ private:
 
 class ElementHandleOwner : public WeakHandleOwner {
 public:
-    bool isReachableFromOpaqueRoots(Handle<JSC::Unknown> handle, void*, SlotVisitor& visitor, const char** reason) override
+    bool isReachableFromOpaqueRoots(JSC::Handle<JSC::Unknown> handle, void*, SlotVisitor& visitor, const char** reason) override
     {
         if (UNLIKELY(reason))
             *reason = "JSC::Element is opaque root";


### PR DESCRIPTION
When I run `./make` I get the following error on macOS:
```
In file included from DerivedSources/JavaScriptCore/unified-sources/UnifiedSource-0284c6ac-1.cpp:8:
../Source/JavaScriptCore/tools/JSDollarVM.cpp:180:37: error: reference to 'Handle' is ambiguous
    bool isReachableFromOpaqueRoots(Handle<JSC::Unknown> handle, void*, SlotVisitor& visitor, const char** reason) override
                                    ^
/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX11.1.sdk/usr/include/MacTypes.h:249:41: note: candidate found by name lookup is 'Handle'
typedef Ptr *                           Handle;
                                        ^
../Source/JavaScriptCore/heap/handle.h:109:29: note: candidate found by name lookup is 'JSC::Handle'
template <typename T> class Handle : public HandleBase, public HandleConverter<Handle<T>, T> {
```

This change fixed it and allowed me to build WebCore successfully.

Tested on
macOS 11.2.2
clang --version: Apple clang version 12.0.0 (clang-1200.0.32.29)
Xcode Version 12.4 (12D4e)