### PR TITLE
Allow running off the main thread on macOS

### DIFF
--- a/Source/WTF/wtf/Platform.h
+++ b/Source/WTF/wtf/Platform.h
@@ -693,7 +693,8 @@
 #define HAVE_TM_GMTOFF 1
 #define HAVE_TM_ZONE 1
 #define HAVE_TIMEGM 1
-#define HAVE_PTHREAD_MAIN_NP 1
+// Allows running off the main thread on macOS
+#define HAVE_PTHREAD_MAIN_NP 0
 
 #if CPU(X86_64) || CPU(ARM64)
 #define HAVE_INT128_T 1


### PR DESCRIPTION
This still does not allow calling Ultralight from different threads, but with this change it is now possible to use a separate worker thread for interacting with Ultralight.

[Context on Discord](https://discord.com/channels/738779721541746696/782753452656558100/785613281561673729)