### PR TITLE
Fix ambigious use of Handle, use JSC::Handle instead

### DIFF
--- a/Source/JavaScriptCore/tools/JSDollarVM.cpp
+++ b/Source/JavaScriptCore/tools/JSDollarVM.cpp
@@ -176,7 +176,7 @@ private:
 
 class ElementHandleOwner : public WeakHandleOwner {
 public:
-    bool isReachableFromOpaqueRoots(Handle<JSC::Unknown> handle, void*, SlotVisitor& visitor, const char** reason) override
+    bool isReachableFromOpaqueRoots(JSC::Handle<JSC::Unknown> handle, void*, SlotVisitor& visitor, const char** reason) override
     {
         if (UNLIKELY(reason))
             *reason = "JSC::Element is opaque root";


### PR DESCRIPTION
In JSDollarVM, the method isReachableFromOpaqueRoots takes a `Handle<JSC::Unknown>`, but this ambiguous since both JavaScriptCore/heap/Handle.h and the latest MacOS SDK (12.0) declare handle.

Specifically, the MacOS SDK declares in /usr/include/MacTypes.h:

```C
typedef char *                          Ptr;
typedef Ptr *                           Handle;
```